### PR TITLE
Fixes Django dependency issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description=read('README.md'),
     zip_safe = False,
     install_requires=[
-        'Django>=1.4',
+        "Django>=1.8,<2.0",
         'markdown',
         'django-sekizai',
         'django-mptt',


### PR DESCRIPTION
Updates install_requires to match [upstream master: `Django>=1.8,<2.0`](https://github.com/django-wiki/django-wiki/blob/master/setup.py#L37)
    
Django 2.0 was released on 2 Dec 2017, and it requires python3.

**JIRA tickets**: OC-3435

**Merge deadline**: ASAP

**Testing instructions**:

1. Run these commands on a ginkgo devstack:
   ```python
   edxapp@vagrant:~/edx-platform$ pip uninstall django-wiki -y
   edxapp@vagrant:~/edx-platform$ pip install "git+https://github.com/open-craft/django-wiki.git@jill/fix-django-install-requires#egg=django-wiki==0.0.10"
   ```
1. Note: "Requirement already satisfied: Django<2.0,>=1.8" 

**Reviewers**
- [ ] TBD